### PR TITLE
fix #19 캐시파일 재생성시 사이트 대표 이미지를 불러오지 못하는 문제 수정

### DIFF
--- a/seo.controller.php
+++ b/seo.controller.php
@@ -160,12 +160,47 @@ class seoController extends seo
 		}
 
 		$piece->title = $this->getBrowserTitle($piece->document_title);
-
-		if($oCacheHandler->isSupport()) {
-			$cache_key = 'seo:site_image';
-			$site_image = $oCacheHandler->get($cache_key);
-			if($site_image) {
-				$site_image['url'] = $config->site_image_url;
+		
+		//if site image exists
+		if($config->site_image_url) {
+			//if cache is supported, try to use it
+			if($oCacheHandler->isSupport())
+			{
+				$cache_key = 'seo:site_image';
+				$site_image = $oCacheHandler->get($cache_key);
+				
+				//if cache exists,use cache
+				if($site_image)
+				{
+					$site_image['url'] = $config->site_image_url;
+				}
+				//else(no cache exists), re-generate cache
+				else
+				{
+					list($width, $height) = @getimagesize(_XE_PATH_ . 'files/attach/site_image/' . $config->site_image);
+					$site_image_dimension = array(
+						'width' => $width,
+						'height' => $height
+					);
+					$cache_key = 'seo:site_image';
+					$oCacheHandler->put($cache_key, $site_image_dimension);
+					
+					$site_image = array(
+						'url' => $config->site_image_url,
+						'width' => $width,
+						'height' => $height
+					);
+				}
+			}
+			//do not use cache if no cache available
+			else
+			{
+				list($width, $height) = @getimagesize(_XE_PATH_ . 'files/attach/site_image/' . $config->site_image);
+				$site_image = array(
+					'url' => $config->site_image_url,
+					'width' => $width,
+					'height' => $height
+				);
 			}
 			$piece->image[] = $site_image;
 		}


### PR DESCRIPTION
사이트 이미지가 존재하는지 여부를 체크하지 않고 캐시파일 유무만 체크해서 캐시파일이 사라지는 순간 사이트 이미지도 없는 것으로 처리되는 문제점을 수정합니다.
추가로 캐시 미지원 환경에서는 사이트 이미지 처리가 전혀 되지 않는 문제점을 수정합니다.